### PR TITLE
fix: resolve commands directory path for both bundled and dev environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-agent-modes",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenCode plugin to switch agent modes between performance and economy presets",
   "module": "src/index.ts",
   "main": "dist/index.js",

--- a/src/config/command-installer.ts
+++ b/src/config/command-installer.ts
@@ -1,55 +1,115 @@
-import { copyFileSync, mkdirSync, readdirSync, existsSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+/**
+ * @fileoverview Command file installer for OpenCode slash commands.
+ *
+ * This module handles copying slash command markdown files from the plugin's
+ * commands directory to OpenCode's configuration directory during plugin
+ * initialization. This ensures command files are available without requiring
+ * manual postinstall script execution.
+ *
+ * @module config/command-installer
+ */
+
+import { copyFileSync, mkdirSync, readdirSync, existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 /**
- * Target directory for OpenCode command files
+ * Target directory for OpenCode command files.
+ *
+ * This is the standard location where OpenCode looks for slash command
+ * markdown files: `~/.config/opencode/command/`
+ *
+ * @constant
  */
-const COMMANDS_DEST = join(homedir(), ".config", "opencode", "command");
+const COMMANDS_DEST = join(homedir(), '.config', 'opencode', 'command')
+
+/**
+ * Finds the commands source directory.
+ *
+ * Tries multiple candidate paths to support both production and development
+ * environments by checking relative paths from the current module location:
+ * - Production: bundled dist/index.js -> ../commands
+ * - Development: src/config/command-installer.ts -> ../../commands
+ *
+ * The function checks each candidate path in order and returns the first
+ * one that exists on the filesystem.
+ *
+ * @returns Absolute path to commands directory if found, or null if none
+ *          of the candidate paths exist
+ *
+ * @example
+ * ```typescript
+ * const commandsDir = findCommandsDir();
+ * if (commandsDir) {
+ *   console.log(`Commands found at: ${commandsDir}`);
+ * } else {
+ *   console.log('Commands directory not found');
+ * }
+ * ```
+ */
+function findCommandsDir(): string | null {
+  const __dirname = dirname(fileURLToPath(import.meta.url))
+
+  // Try multiple paths to support different build outputs
+  const candidates = [
+    join(__dirname, '..', 'commands'),       // Production: dist/ -> commands/
+    join(__dirname, '..', '..', 'commands'), // Development: src/config/ -> commands/
+  ]
+
+  return candidates.find(existsSync) ?? null
+}
 
 /**
  * Copies slash command markdown files to OpenCode's command directory.
  *
  * This function is called during plugin initialization to ensure
  * command files are available without manual postinstall execution.
+ * It creates the destination directory if it doesn't exist and copies
+ * all `.md` files from the source commands directory.
  *
- * @returns Number of files copied, or -1 if source directory not found
+ * The function is designed to be non-fatal: if copying fails (e.g., due to
+ * permission issues), it logs a warning but doesn't throw an error,
+ * allowing the plugin to continue initializing.
+ *
+ * @returns Number of files successfully copied, or -1 if source directory
+ *          not found or an error occurred during copying
+ *
+ * @example
+ * ```typescript
+ * const copied = copyCommandFiles();
+ * if (copied > 0) {
+ *   console.log(`Copied ${copied} command files`);
+ * }
+ * ```
  */
 export function copyCommandFiles(): number {
-  // Resolve the commands directory relative to this file
-  // In dist: dist/config/command-installer.js -> dist/../commands = commands/
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  const commandsSrc = join(__dirname, "..", "..", "commands");
+  const commandsSrc = findCommandsDir()
 
-  // Skip if commands directory doesn't exist (shouldn't happen in production)
-  if (!existsSync(commandsSrc)) {
-    console.warn(
-      "[agent-mode-switcher] Commands directory not found:",
-      commandsSrc
-    );
-    return -1;
+  // Skip if commands directory doesn't exist
+  if (!commandsSrc) {
+    return -1
   }
 
   try {
-    // Ensure destination directory exists
-    mkdirSync(COMMANDS_DEST, { recursive: true });
+    // Create destination directory with parents if needed
+    mkdirSync(COMMANDS_DEST, { recursive: true })
 
-    // Find all markdown files in the commands directory
-    const files = readdirSync(commandsSrc).filter((f) => f.endsWith(".md"));
+    // Filter only markdown files
+    const files = readdirSync(commandsSrc).filter((f) => f.endsWith('.md'))
 
-    // Copy each command file to the OpenCode config directory
+    // Copy each command file to the destination
     for (const file of files) {
-      copyFileSync(join(commandsSrc, file), join(COMMANDS_DEST, file));
+      copyFileSync(join(commandsSrc, file), join(COMMANDS_DEST, file))
     }
 
-    return files.length;
+    return files.length
   } catch (error) {
     // Non-fatal: log warning but don't block plugin initialization
     console.warn(
-      "[agent-mode-switcher] Warning: Could not copy command files:",
+      '[agent-mode-switcher] Warning: Could not copy command files:',
       error instanceof Error ? error.message : String(error)
-    );
-    return -1;
+    )
+    return -1
   }
 }


### PR DESCRIPTION
## Summary

<img width="1280" height="194" alt="image" src="https://github.com/user-attachments/assets/45df69d7-aceb-4e15-9852-150e1bdfe526" />


- Fix path resolution in `command-installer.ts` that was broken after bundling
- Add `findCommandsDir()` function to try multiple candidate paths
- Support both production (`dist/index.js`) and development (`src/config/`) environments
- Remove unnecessary warning log when commands directory is not found
- Bump version to 0.1.2

## Background

When all code is bundled into `dist/index.js`, the relative path `"../.."` went too far up the directory tree, causing the commands directory to not be found. The fix tries multiple paths in order:

1. `../commands` (for bundled production)
2. `../../commands` (for development)

## Test plan

- [x] Verify commands are copied to `~/.config/opencode/command/` on plugin initialization
- [x] Test in production (npm installed package)
- [x] Test in development (local source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)