### PR TITLE
chore: add .worktrees/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 plan/
 node_modules/
 dist/
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` directory to `.gitignore` to exclude worktree directories from version control

🤖 Generated with [Claude Code](https://claude.com/claude-code)