### PR TITLE
docs: remove star promotion section and add .worktrees/ to gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,6 @@ OpenCode plugin to switch agent models between performance and economy modes.
   <img src="assets/image/sample.png" width="700" alt="Change mode example" />
 </p>
 
-## Star this repo to keep me motivated ⭐
-
-I build this in my spare time. Every star shows that my work is valued and keeps me going!
-
-![Star](docs/images/star-github.gif)
-
 ## Features
 
 - Switch between different model presets (performance, economy, or custom)


### PR DESCRIPTION
## Summary
- Remove "Star this repo to keep me motivated" section from README
- Add `.worktrees/` to `.gitignore` (previous commit)

## Test plan
- [x] Verify README renders correctly without the removed section