### PR TITLE
🚀 Release v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-agent-modes",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "OpenCode plugin to switch agent modes between performance and economy presets",
   "module": "src/index.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Release v0.3.2

## Changes

- fix: make oh-my-opencode optional in ModePreset (#15)
  - Users without the oh-my-opencode plugin no longer get errors on plugin startup
  - Added 7 new test cases (82 total, all passing)
  - Added JSDoc notes for optional oh-my-opencode behavior

## Version Bump

- **Previous**: v0.3.1
- **Next**: v0.3.2
- **Type**: patch